### PR TITLE
Replace inline scripts and add Content-Security-Policy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' fonts.googleapis.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' ws: wss:; media-src *" />
 		<title>Damus</title>
 		<link rel="stylesheet" href="css/vars.css?v=2">
 		<link rel="stylesheet" href="css/utils.css?v=2">
@@ -18,30 +19,24 @@
 		<script defer src="js/damus.js?v=94"></script>
 	</head>
 	<body>
-		<script>
-		// This is our main entry.
-		// https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
-		addEventListener('DOMContentLoaded', (ev) => {
-			damus_web_init();
-		});
-		</script>
+		<script src="js/main.js"></script>
 		<div id="gsticker" title="This is alpha software.">αlpha</div>
 
 		<nav id="gnav" class="">
-			<button class="icon" role="open-gnav" title="Open Menu" onclick="toggle_gnav(this)">
+			<button class="icon" role="open-gnav" title="Open Menu" data-action="toggle_gnav">
 				<img class="icon svg invert" src="icon/logo.svg"/>
 			</button>
-			<button class="icon" role="home" title="Home" onclick="switch_view('home')">
+			<button class="icon" role="home" title="Home" data-action="switch_view" data-target="home">
 				<img class="icon svg invert" src="icon/home.svg"/>
 			</button>
-			<button class="icon" role="explore" title="Explore" onclick="switch_view('explore')">
+			<button class="icon" role="explore" title="Explore" data-action="switch_view" data-target="explore">
 				<img class="icon svg invert" src="icon/explore.svg"/>
 			</button>
-			<button class="icon" role="notifications" title="Notifications" onclick="switch_view('notifications')">
+			<button class="icon" role="notifications" title="Notifications" data-action="switch_view" data-target="notifications">
 				<img class="icon svg invert" src="icon/notifications.svg"/>
 				<div class="new-notifications hide"></div>
 			</button>
-			<button class="icon" role="sign-out" title="Sign Out" onclick="press_logout()">
+			<button class="icon" role="sign-out" title="Sign Out" data-action="press_logout">
 				<img class="icon svg invert" src="icon/sign-out.svg"/>
 			</button>
 		</nav>
@@ -54,22 +49,22 @@
 						<img class="icon svg" title="Damus" src="icon/logo-inverted.svg"/>
 					</div>
 					<button role="home" class="nav icon" 
-						title="Home" onclick="switch_view('home')">
+						title="Home" data-action="switch_view" data-target="home">
 						<img class="icon svg inactive" src="icon/home.svg"/>
 						<img class="icon svg active" src="icon/home-active.svg"/>
 					</button>
 					<button role="explore" class="nav icon" 
-						title="Explore" onclick="switch_view('explore')">
+						title="Explore" data-action="switch_view" data-target="explore">
 						<img class="icon svg inactive" src="icon/explore.svg"/>
 						<img class="icon svg active" src="icon/explore-active.svg"/>
 					</button>
 					<button role="notifications" class="nav icon" 
-						title="Notifications" onclick="switch_view('notifications')">
+						title="Notifications" data-action="switch_view" data-target="notifications">
 						<img class="icon svg inactive" src="icon/notifications.svg"/>
 						<img class="icon svg active" src="icon/notifications-active.svg"/>
 						<div class="new-notifications hide"></div>
 					</button>
-					<button title="Sign Out" class="nav icon" onclick="press_logout()">
+					<button title="Sign Out" class="nav icon" data-action="press_logout">
 						<img class="icon svg" src="icon/sign-out.svg"/>
 					</button>
 				</div>
@@ -84,16 +79,17 @@
 							<!-- To be loaded dynamically. -->
 						</div>
 						<div>
-							<textarea placeholder="What's up?" 
-									  oninput="post_input_changed(this)" 
+							<textarea placeholder="What's up?"
+									  data-on-input="post_input_changed"
 									  class="post-input" id="post-input"></textarea>
 							<div class="post-tools">
 								<input id="content-warning-input" class="cw hide" type="text" placeholder="Reason"/>
 								<button title="Mark this message as sensitive." 
-									onclick="toggle_cw(this)" class="cw icon">
+									data-action="toggle_cw"
+									class="cw icon">
 									<img class="icon svg small" src="icon/content-warning.svg"/>
 								</button>
-								<button onclick="send_post(this)" class="action" 
+								<button data-action="send_post" class="action"
 									role="send" id="post-button" disabled>Send</button>
 							</div>
 						</div>
@@ -131,10 +127,11 @@
 									<img class="icon" src="icon/message-user.svg"/></button>
 								-->
 								<button class="icon" role="copy-pk"
-									data-pk="" onclick="click_copy_pk(this)" title="Copy Public Key">
+									data-action="click_copy_pk"
+									data-pk="" title="Copy Public Key">
 									<img class="icon svg" src="icon/pubkey.svg"/></button>
 								<button class="action" role="follow-user" data-pk=""
-									onclick="click_toggle_follow_user(this)">Follow</button>
+									data-action="click_toggle_follow_user">Follow</button>
 							</div>
 						</div>
 						<div>
@@ -152,16 +149,16 @@
 			<div id="reply-modal-content" class="modal-content">
 				<header>
 					<label>Reply To</label>
-					<button class="icon" onclick="close_reply()">
+					<button class="icon" data-action="close_reply">
 						<img class="icon svg" src="icon/close-modal.svg"/>
 					</button>
 				</header>
 				<div id="replying-to"></div>
 				<div id="replybox">
-					<textarea id="reply-content" class="post-input" oninput="post_input_changed(this)"
+					<textarea id="reply-content" class="post-input" data-on-input="post_input_changed"
 						placeholder="Write your reply here..."></textarea>
 					<div class="post-tools">
-						<button id="reply-button" class="action" onclick="do_send_reply()">
+						<button id="reply-button" class="action" data-action="do_send_reply">
 							Reply
 						</button>
 					</div>

--- a/web/js/damus.js
+++ b/web/js/damus.js
@@ -3,6 +3,7 @@ let DAMUS
 
 const BOOTSTRAP_RELAYS = [
 	"wss://relay.damus.io",
+	"wss://nostr-pub.semisol.dev",
 	"wss://nostr-relay.wlvs.space",
 	"wss://nostr-pub.wellorder.net"
 ]
@@ -1050,6 +1051,8 @@ function redraw_events(damus, view) {
 
 	const events_el = damus.view_el.querySelector(`#${view.name}-view > .events`)
 	events_el.innerHTML = render_events(damus, view)
+
+	bind_buttons(events_el)
 }
 
 function redraw_timeline_events(damus, name) {
@@ -1498,7 +1501,7 @@ function reply_to(evid) {
 	const ev = DAMUS.all_events[evid]
 	const view = get_current_view()
 	replying_to.innerHTML = render_event(DAMUS, view, ev, {is_composing: true, nobar: true, max_depth: 1})
-
+	bind_buttons(replying_to)
 	replybox.focus()
 }
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,0 +1,87 @@
+// This is our main entry.
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
+
+addEventListener('DOMContentLoaded', () => {
+    damus_web_init()
+
+    bind_buttons(document.body)
+})
+
+function bind_buttons(el) {
+    const actionButtons = el.querySelectorAll('[data-action]')
+    actionButtons.forEach((button) => {
+        button.addEventListener('click', (ev) => {
+            const action = button.getAttribute('data-action')
+
+            switch (action) {
+                case 'toggle_gnav':
+                    toggle_gnav(button)
+                    break
+                case 'switch_view':
+                    switch_view(button.getAttribute('data-target'))
+                    break
+                case 'delete_post':
+                    delete_post(button.getAttribute('data-target'))
+                    break
+                case 'reply_to':
+                    reply_to(button.getAttribute('data-target'))
+                    break
+                case 'expand_thread':
+                    expand_thread(button.getAttribute('data-target'))
+                    break
+                case 'delete_post_confirm':
+                    delete_post_confirm(button.getAttribute('data-target'))
+                    break
+                case 'show_profile':
+                    show_profile(button.getAttribute('data-target'))
+                    break
+                case 'press_logout':
+                    press_logout()
+                    break
+                case 'toggle_cw':
+                    toggle_cw(button)
+                    break
+                case 'send_post':
+                    send_post(button)
+                    break
+                case 'click_copy_pk':
+                    click_copy_pk(button)
+                    break
+                case 'click_toggle_follow_user':
+                    click_toggle_follow_user(button)
+                    break
+                case 'close_reply':
+                    close_reply()
+                    break
+                case 'do_send_reply':
+                    do_send_reply()
+                    break
+                case 'send_reply':
+                    const emoji = button.getAttribute('data-emoji')
+                    const reacting_to = button.getAttribute('data-reacting-to')
+                    send_reply(emoji, reacting_to)
+                    break
+                case 'click_event':
+                    // "click_event" is not fully implemented
+                    // it is used to open a thread
+                    // could be renamed to "show_thread"
+                    click_event(button)
+                    break
+            }
+        })
+    })
+
+    const onInputElements = el.querySelectorAll('[data-on-input]')
+    onInputElements.forEach((el) => {
+        el.addEventListener('input', (ev) => {
+            const action = el.getAttribute('data-on-input')
+
+            switch (action) {
+                case 'post_input_changed':
+                    post_input_changed(el)
+                    break
+            }
+        })
+    })
+}
+

--- a/web/js/ui/render.js
+++ b/web/js/ui/render.js
@@ -33,7 +33,7 @@ function render_thread_collapsed(model, ev, opts)
 {
 	if (opts.is_composing)
 		return ""
-	return `<div onclick="expand_thread('${ev.id}')" class="thread-collapsed">
+	return `<div data-action="expand_thread" data-target="${ev.id}" class="thread-collapsed">
 		<div class="thread-summary clickable event-message">
 			Read More  
 			<img class="icon svg small" src="icon/read-more.svg"/>
@@ -197,7 +197,7 @@ function render_event(damus, view, ev, opts={}) {
 			<div class="info">
 				${render_name(ev.pubkey, profile)}
 				<span class="timestamp">${delta}</span>
-				<button class="icon" title="View Thread" role="view-event" data-eid="${ev.id}" onclick="click_event(this)">
+				<button class="icon" title="View Thread" role="view-event" data-eid="${ev.id}" data-target="${ev.id}" data-action="click_event">
 					<img class="icon svg small" src="icon/open-thread.svg"/>
 				</button>
 			</div>
@@ -212,19 +212,19 @@ function render_event(damus, view, ev, opts={}) {
 function render_react_onclick(our_pubkey, reacting_to, emoji, reactions) {
 	const reaction = reactions[our_pubkey]
 	if (!reaction) {
-		return `onclick="send_reply('${emoji}', '${reacting_to}')"`
+		return `data-action="send_reply" data-reacting-to="${reacting_to}" data-emoji="${emoji}"`
 	} else {
-		return `onclick="delete_post('${reaction.id}')"`
+		return `data-action="delete_post" data-target="${reaction.id}"`
 	}
 }
 
 function render_reaction_group(model, emoji, reactions, reacting_to) {
 	const pfps = Object.keys(reactions).map((pk) => render_reaction(model, reactions[pk]))
 
-	let onclick = render_react_onclick(model.pubkey, reacting_to.id, emoji, reactions)
+	let react_onclick = render_react_onclick(model.pubkey, reacting_to.id, emoji, reactions)
 
 	return `
-	<span ${onclick} class="reaction-group clickable">
+	<span ${react_onclick} class="reaction-group clickable">
 	  <span class="reaction-emoji">
 	  ${emoji}
 	  </span>
@@ -246,7 +246,7 @@ function render_action_bar(damus, ev, can_delete) {
 	let delete_html = ""
 	if (can_delete)
 		delete_html = `
-	<button class="icon" title="Delete" onclick="delete_post_confirm('${ev.id}')">
+	<button class="icon" title="Delete" data-action="delete_post_confirm" data-target="${ev.id}">
 		<img class="icon svg small" src="icon/event-delete.svg"/>
 	</button>`
 
@@ -256,15 +256,13 @@ function render_action_bar(damus, ev, can_delete) {
 	const react_onclick = render_react_onclick(damus.pubkey, ev.id, like, likes)
 	return `
 	<div class="action-bar">
-		<button class="icon" title="Reply" onclick="reply_to('${ev.id}')">
+		<button class="icon" title="Reply" data-action="reply_to" data-target="${ev.id}">
 			<img class="icon svg small" src="icon/event-reply.svg"/>
 		</button>
 		<button class="icon react heart" ${react_onclick} title="Like">
 			<img class="icon svg small" src="icon/event-like.svg"/>
 		</button>
-		<!--<button class="icon" title="Share" onclick=""><i class="fa fa-fw fa-link"></i></a>-->
 		${delete_html}	
-		<!--<button class="icon" title="View raw Nostr event." onclick=""><i class="fa-solid fa-fw fa-code"></i></a>-->
 	</div>
 	`
 }
@@ -314,7 +312,7 @@ function render_mentioned_name(pk, profile) {
 
 function render_name(pk, profile, prefix="") {
 	return `
-	<span class="username clickable" onclick="show_profile('${pk}')" 
+	<span class="username clickable" data-action="show_profile" data-target="${pk}" 
 		data-pk="${pk}">${prefix}${render_name_plain(profile)}
 	</span>`
 }
@@ -326,7 +324,6 @@ function render_deleted_name() {
 function render_pfp(pk, profile) {
 	const name = render_name_plain(profile)
 	return `<img class="pfp" title="${name}" 
-	onerror="this.onerror=null;this.src='${robohash(pk)}';" 
 	src="${get_picture(pk, profile)}">`
 }
 


### PR DESCRIPTION
This PR adds a fairly restrictive Content-Security-Policy to this client app. Even If an attacker manages to inject a script, it won't be executed in modern browsers.
To do this, I replaced the inline scripts and on*-handlers with a new "main.js" script that contains a function to bind the buttons.
Note: If an attacker injects fake buttons that contain the same `data-action` attributes, he could trick the user into executing an action (for example liking a post when a link inside the message is clicked). 
It would be better to only bind the buttons that are included in the html produced by the app (the messages must be excluded).
I haven't thoroughly tested these changes.

btw: I read that you are working on this client currently, please close this PR If you already solved those security problems.