### PR TITLE
Use history.pushState to change url when changing content

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,1 +1,2 @@
 tags
+*.pem

--- a/web/index.html
+++ b/web/index.html
@@ -31,13 +31,13 @@
 			<button class="icon" role="open-gnav" title="Open Menu" onclick="toggle_gnav(this)">
 				<img class="icon svg invert" src="icon/logo.svg"/>
 			</button>
-			<button class="icon" role="home" title="Home" onclick="switch_view('home')">
+			<button class="icon" role="home" title="Home" onclick="navigate('home')">
 				<img class="icon svg invert" src="icon/home.svg"/>
 			</button>
-			<button class="icon" role="explore" title="Explore" onclick="switch_view('explore')">
+			<button class="icon" role="explore" title="Explore" onclick="navigate('explore')">
 				<img class="icon svg invert" src="icon/explore.svg"/>
 			</button>
-			<button class="icon" role="notifications" title="Notifications" onclick="switch_view('notifications')">
+			<button class="icon" role="notifications" title="Notifications" onclick="navigate('notifications')">
 				<img class="icon svg invert" src="icon/notifications.svg"/>
 				<div class="new-notifications hide"></div>
 			</button>
@@ -54,17 +54,17 @@
 						<img class="icon svg" title="Damus" src="icon/logo-inverted.svg"/>
 					</div>
 					<button role="home" class="nav icon" 
-						title="Home" onclick="switch_view('home')">
+						title="Home" onclick="navigate('home')">
 						<img class="icon svg inactive" src="icon/home.svg"/>
 						<img class="icon svg active" src="icon/home-active.svg"/>
 					</button>
 					<button role="explore" class="nav icon" 
-						title="Explore" onclick="switch_view('explore')">
+						title="Explore" onclick="navigate('explore')">
 						<img class="icon svg inactive" src="icon/explore.svg"/>
 						<img class="icon svg active" src="icon/explore-active.svg"/>
 					</button>
 					<button role="notifications" class="nav icon" 
-						title="Notifications" onclick="switch_view('notifications')">
+						title="Notifications" onclick="navigate('notifications')">
 						<img class="icon svg inactive" src="icon/notifications.svg"/>
 						<img class="icon svg active" src="icon/notifications-active.svg"/>
 						<div class="new-notifications hide"></div>

--- a/web/js/damus.js
+++ b/web/js/damus.js
@@ -141,6 +141,17 @@ async function damus_web_init()
 
 async function damus_web_init_ready()
 {
+	history.replaceState({ page: "home" }, null, '');
+	window.onpopstate = (event) => {
+		if (event.state.page === "profile") {
+			show_profile(event.state.opts.pk);
+		}
+
+		// in case page is null or undefined, fallback to the home view
+		switch_view(event.state.page || 'home');
+	}
+	
+
 	const model = init_home_model()
 	DAMUS = model
 	model.pubkey = await get_pubkey()
@@ -170,7 +181,7 @@ async function damus_web_init_ready()
 	load_cache(model)
 	model.view_el = document.querySelector("#view")
 
-	switch_view('home')
+	switch_view('home');
 
 	document.addEventListener('visibilitychange', () => {
 		update_title(model)
@@ -897,8 +908,29 @@ function get_view_el(name)
 	return DAMUS.view_el.querySelector(`#${name}-view`)
 }
 
+function change_url(name, opts = {}) {
+	let pushStateUrl = `/${name}`;
+	if (opts.pk) {
+		pushStateUrl = `${pushStateUrl}/${opts.pk}`;
+	}
+	window.history.pushState({ page: name, opts }, '', pushStateUrl);
+}
+
+function navigate(name, pk) {
+	if (name === 'profile') {
+		show_profile(pk);
+		change_url(name, { pk });
+	} else {
+		change_url(name);
+	}
+
+
+	switch_view(name);
+}
+
 function switch_view(name, opts={})
 {
+	// change_url(name, opts);
 	if (name === DAMUS.current_view) {
 		log_debug("Not switching to '%s', we are already there", name)
 		return

--- a/web/js/ui/render.js
+++ b/web/js/ui/render.js
@@ -314,7 +314,7 @@ function render_mentioned_name(pk, profile) {
 
 function render_name(pk, profile, prefix="") {
 	return `
-	<span class="username clickable" onclick="show_profile('${pk}')" 
+	<span class="username clickable" onclick="navigate('profile', '${pk}')" 
 		data-pk="${pk}">${prefix}${render_name_plain(profile)}
 	</span>`
 }

--- a/web/js/ui/util.js
+++ b/web/js/ui/util.js
@@ -56,7 +56,6 @@ function update_notification_markers(active) {
  * TODO handle async waiting for relay not yet connected
  */
 function show_profile(pk) {
-	switch_view("profile");
 	const profile = DAMUS.profiles[pk];
 	const el = find_node("#profile-view");
 	// TODO show loading indicator then render


### PR DESCRIPTION
The changes on this commit aim to add the capability to add url navigations. Prior to these changes, only the content would be update, now we also change the url.

For the profile, the Public Key is being used to build the url, like `/profile/PK_HERE`.

There is one know issue, if the user navigates to a page, let's say `/explore` and hits the refresh button, a **404** error will be thrown, that's because the `/explore` endpoint does not exist in the server. I am not sure what the desired solution for this issue could be.