### PR TITLE
Add NIP-05 Creation Tool to Damus Key Converter

### DIFF
--- a/key/creation.js
+++ b/key/creation.js
@@ -1,0 +1,20 @@
+document.getElementById("createButton").addEventListener("click", function() {
+      let key = document.getElementById("keyInput").value;
+      let name = document.getElementById("nameInput").value;
+      let json = {
+        "names": {
+          [name]: key
+        }
+      };
+      let jsonStr = JSON.stringify(json);
+      let blob = new Blob([jsonStr], { type: "application/json" });
+      let htaccess = `<IfModule mod_headers.c>
+   Header set Access-Control-Allow-Origin "*"
+ </IfModule>`;
+      let zip = new JSZip();
+      zip.folder(".well-known").file("nostr.json", blob);
+      zip.file(".htaccess", htaccess);
+      zip.generateAsync({ type: "blob" }).then(function(content) {
+        saveAs(content, "nip05.zip");
+      });
+    });

--- a/key/index.html
+++ b/key/index.html
@@ -57,5 +57,6 @@
 
 	<script src="bech32.js" ></script>
 	<script src="key.js?v=3" ></script>
+	<script src="creation.js" ></script>
     </body>
 </html>


### PR DESCRIPTION
Just in case you want to add this feature.
It comes from my NIP-05 Creation Tool you find here https://resources.davidcoen.it/nip05creator/ .

The tool generates a .zip file. Inside you have a .htaccess file for your Apache server and a folder which contains a JSON called "nostr.json". You simply need to paste the unzipped contents in the domain you prefer. For example, I wanted to put my NIP05 identifier in my domain davidcoen.it, so I pasted .htaccess file and the .well-known folder in the public.html folder.