### PR TITLE
Purple checkout flows without Damus iOS — Part deux

### DIFF
--- a/src/components/NostrProfile.tsx
+++ b/src/components/NostrProfile.tsx
@@ -4,21 +4,22 @@ import { nip19 } from "nostr-tools"
 import { Profile } from "@/utils/PurpleUtils";
 
 export interface NostrProfileProps {
-  profile: Profile
+  pubkey: string
+  profile: Profile | null
   profileHeader: React.ReactNode
   profileFooter: React.ReactNode
 }
 
 export function NostrProfile(props: NostrProfileProps) {
   const intl = useIntl()
-  const { profile } = props
-  const npub = nip19.npubEncode(profile.pubkey)
+  const { profile, pubkey } = props
+  const npub = nip19.npubEncode(pubkey)
 
   return (<>
     <div className="mt-2 mb-4 flex flex-col items-center">
       {props.profileHeader}
       <div className="mt-4 flex flex-col gap-1 items-center justify-center mb-4">
-        <Image src={profile?.picture || ("https://robohash.org/" + (profile.pubkey))} width={64} height={64} className="rounded-full" alt={profile.name || intl.formatMessage({ id: "purple.profile.unknown-user", defaultMessage: "Generic user avatar" })} />
+        <Image src={profile?.picture || ("https://robohash.org/" + (pubkey))} width={64} height={64} className="rounded-full" alt={profile?.name || intl.formatMessage({ id: "purple.profile.unknown-user", defaultMessage: "Generic user avatar" })} />
         <div className="text-purple-100/90 font-semibold text-lg">
           {profile?.name || (npub.substring(0, 8) + ":" + npub.substring(npub.length - 8))}
         </div>

--- a/src/components/NostrUserInput.tsx
+++ b/src/components/NostrUserInput.tsx
@@ -91,8 +91,9 @@ export function NostrUserInput(props: { pubkey: string | null, setPubkey: (pubke
         </div>
       </div>
     )}
-    {profile && (<>
+    {((profile || profile === null) && props.pubkey) && (<>
       <NostrProfile
+        pubkey={props.pubkey}
         profile={profile}
         profileHeader={props.profileHeader}
         profileFooter={props.profileFooter}

--- a/src/components/sections/PurpleCheckoutDetails/Step2UserVerification.tsx
+++ b/src/components/sections/PurpleCheckoutDetails/Step2UserVerification.tsx
@@ -120,8 +120,9 @@ export function Step2UserVerification(props: Step2UserVerificationProps) {
         </TabsContent>
       </Tabs>
     }
-    {step2Done && profile && <>
+    {step2Done && pubkey && (profile !== undefined)  && <>
       <NostrProfile
+        pubkey={pubkey}
         profile={profile}
         profileHeader={<>
           <div className="text-purple-200/50 font-normal text-sm">

--- a/src/hooks/usePurpleLoginSession.ts
+++ b/src/hooks/usePurpleLoginSession.ts
@@ -27,6 +27,12 @@ export function usePurpleLoginSession(setError: (message: string) => void) {
             'Authorization': 'Bearer ' + sessionToken
           },
         });
+        
+        if (response.status === 401) {
+          setSessionToken(null);
+          setAccountInfo(null);
+          return;
+        }
 
         if (!response.ok) {
           setError("Failed to get account info from our servers. Please wait a few minutes and refresh the page. If the problem persists, please contact support.");


### PR DESCRIPTION
This PR includes two fixes:
1. It fixes the login and checkout flow for npubs that do not have a profile (or cases where a profile cannot be found)
2. It fixes an expired session token being interpreted as an error on the frontend — it now discards the session token and signals that the user is logged out.

## Testing

Did some rough testing. Did not test the full checkout flow for pubkeys without profile, only partial flows

PASS

**damus-website:** `4899b73e738740f55f41db400ea8caa7187f80eb`
**damus-api:** `8bdbd179536da01c3a74b1c8cb5cd7427437c672` (Equivalent to `9a32bea2ef9515a2fdba87cbdae40b9c9fbc9fab`, the current tip of master)
**Node.js version:** v18.20.4
**Setup:** 
- Local test setup, with CORS configured
- jb55's LN node

**Coverage:**
1. Checkout without profile:
    1. On checkout, enter a pubkey without profile: `npub14wlmnz4hus52pvkf9axywdv5z38jucpst3xalg6vaptfvdcadmrqplyd7w`. Ensure that the profile and the "continue" button appears. The profile shows a robohash image and abbreviated npub as the name.
    2. Click continue and ensure the OTP screen shows up
2. Checkout with profile:
    1. On checkout, enter a pubkey with a profile.
    2. Click continue and do the OTP verification
    3. Make sure the payment QR code appears, and everything else looks normal
    4. Refresh page, to check for refresh stability.
3. Login to pubkey without profile
    1. Go to login page, enter `npub14wlmnz4hus52pvkf9axywdv5z38jucpst3xalg6vaptfvdcadmrqplyd7w`
    2. Ensure that the placeholder profile shows up
4. Login to pubkey with profile
    1. Go through login to ensure it acts normal
5. Check session expiry
    1. On the server, change `DEFAULT_SESSION_EXPIRY` to be very short, and restart server
    2. Refresh logged in account page after session token is expired. Ensure that no error messages appear, and that user is taken to the login page automatically.
6. Code analysis
    1. Verified all usages of the `NostrProfile` component had their visibility logic updated
